### PR TITLE
Change visibility of Decrypt method to public

### DIFF
--- a/src/PeterPuff.BuderusKm200Reader/BuderusKm200Reader.cs
+++ b/src/PeterPuff.BuderusKm200Reader/BuderusKm200Reader.cs
@@ -71,7 +71,7 @@ namespace PeterPuff.BuderusKm200Reader
             return buffer;
         }
 
-        private string Decrypt(string encrypted)
+        public string Decrypt(string encrypted)
         {
             var decrypted = DecryptStringFromOpenSslAes(encrypted, _key);
             decrypted = decrypted.TrimEnd('\0');


### PR DESCRIPTION
Making this method public means others can leverage your library for the authentication/decryption but handle the HTTP API side of things themselves. Thanks!